### PR TITLE
Simple script for dataset conversion

### DIFF
--- a/python/.envTemplate
+++ b/python/.envTemplate
@@ -3,10 +3,11 @@
 ###########################
 
 ## Used for logging in to Synapse
-# For security purposes, you should provide your apikey rather than
-# your password. Your apikey can be found on My Dashboard > Settings.
-SYN_USERNAME=username
-SYN_APIKEY="apikey"
+# For security purposes, you should provide your personal access token
+# (PAT) rather than your password. You can generate PATs on Synapse by
+# going to Account Settings > Manage Personal Access Tokens.
+export SYN_USERNAME=username
+export SYN_PAT="PAT"
 
 
 ###########################
@@ -15,6 +16,6 @@ SYN_APIKEY="apikey"
 # Providing a valid email and API key will allow up to 10 requests
 # per second. You may experience errors if this information is not
 # provided.
-ENTREZ_EMAIL=email
-ENTREZ_API_KEY=apikey
+export ENTREZ_EMAIL=email
+export ENTREZ_API_KEY=apikey
 

--- a/python/.envTemplate
+++ b/python/.envTemplate
@@ -7,7 +7,7 @@
 # (PAT) rather than your password. You can generate PATs on Synapse by
 # going to Account Settings > Manage Personal Access Tokens.
 export SYN_USERNAME=username
-export SYN_PAT="PAT"
+export SYNAPSE_AUTH_TOKEN="PAT"
 
 
 ###########################

--- a/python/convert_to_dataset.py
+++ b/python/convert_to_dataset.py
@@ -3,7 +3,6 @@
 TODO:
   - use Python client once Dataset support becomes available
   - get Folder annotations and add them to Dataset entity
-  - apiKey will be deprecated, update to PAT in login()
 
 author: verena.chung
 """
@@ -28,7 +27,7 @@ def login():
     try:
         syn = synapseclient.login(
             os.getenv('SYN_USERNAME'),
-            apiKey=os.getenv('SYN_APIKEY'),
+            authToken=os.getenv('SYN_PAT'),
             silent=True)
     except synapseclient.core.exceptions.SynapseNoCredentialsError:
         print("Credentials not found; please manually provide your",

--- a/python/convert_to_dataset.py
+++ b/python/convert_to_dataset.py
@@ -126,8 +126,13 @@ def main():
                             dataset_items=files)
             folder_count += 1
             file_count += len(files)
-        except synapseclient.core.exceptions.SynapseHTTPError:
-            needs_review.append(folder_id)
+        except synapseclient.core.exceptions.SynapseHTTPError as err:
+
+            # 409 Client Error is from adding a dataset with an existing name.
+            # REVIEW. Double-check if this is how Synapse errors should be
+            #         caught.
+            if not str(err).startswith("409 Client Error:"):
+                needs_review.append(folder_id)
 
     # Print summary report.
     print(f"      Number of folders converted: {folder_count}")

--- a/python/convert_to_dataset.py
+++ b/python/convert_to_dataset.py
@@ -131,7 +131,7 @@ def main():
             # 409 Client Error is from adding a dataset with an existing name.
             # REVIEW. Double-check if this is how Synapse errors should be
             #         caught.
-            if not str(err).startswith("409 Client Error:"):
+            if not err.response.status_code == 409:
                 needs_review.append(folder_id)
 
     # Print summary report.

--- a/python/convert_to_dataset.py
+++ b/python/convert_to_dataset.py
@@ -1,4 +1,4 @@
-"""Convert Synapse Folder to Dataset
+"""Create Synapse Dataset Entities
 
 TODO:
   - use Python client once Dataset support becomes available
@@ -94,6 +94,17 @@ def _create_dataset(syn, dataset_name, schema, dataset_items):
         'items': dataset_items
     }
     syn.restPOST("/entity", json.dumps(req_body))
+
+
+def _reset_datasets(syn):
+    """Remove all current datasets."""
+    curr_datasets = [i.get('id') for i in syn.restPOST(
+        "/entity/children", json.dumps({'parentId': PARENT_ID, "includeTypes": ["dataset"]})).get('page')]
+    while curr_datasets:
+        for dataset_id in curr_datasets:
+            syn.restDELETE(f"/entity/{dataset_id}")
+        curr_datasets = [i.get('id') for i in syn.restPOST(
+            "/entity/children", json.dumps({'parentId': PARENT_ID, "includeTypes": ["dataset"]})).get('page')]
 
 
 def main():

--- a/python/convert_to_dataset.py
+++ b/python/convert_to_dataset.py
@@ -1,0 +1,128 @@
+"""Convert Synapse Folder to Dataset
+
+TODO:
+  - use Python client once Dataset support becomes available
+  - get Folder annotations and add them to Dataset entity
+  - apiKey will be deprecated, update to PAT in login()
+
+author: verena.chung
+"""
+
+import os
+import json
+import getpass
+
+import synapseclient
+from synapseclient import Column
+
+PARENT_ID = "syn21498902"
+FOLDERS_ID = "syn22047105"
+
+
+def login():
+    """Log into Synapse. If env variables not found, prompt user.
+
+    Returns:
+        syn: Synapse object
+    """
+    try:
+        syn = synapseclient.login(
+            os.getenv('SYN_USERNAME'),
+            apiKey=os.getenv('SYN_APIKEY'),
+            silent=True)
+    except synapseclient.core.exceptions.SynapseNoCredentialsError:
+        print("Credentials not found; please manually provide your",
+              "Synapse username and password.")
+        username = input("Synapse username: ")
+        password = getpass.getpass("Synapse password: ")
+        syn = synapseclient.login(username, password, silent=True)
+    return syn
+
+
+def create_dataset_schema(syn):
+    """Create schema for creating a Dataset entity.
+
+    Returns:
+        list of ColumnModel IDS
+    """
+    cols = syn.createColumns(
+        columns=[
+            Column(name="id", columnType="ENTITYID"),
+            Column(name="fileName", columnType="STRING", maximumSize=256),
+            Column(name="name", columnType="STRING", maximumSize=256),
+            Column(name="species", columnType="STRING", maximumSize=25),
+            Column(name="dataFormat", columnType="STRING", maximumSize=15),
+            Column(name="assay", columnType="STRING", maximumSize=500),
+            Column(name="tumorType", columnType="STRING", maximumSize=500),
+            Column(name="gender", columnType="STRING", maximumSize=11)
+        ]
+    )
+    return [col.get('id') for col in cols]
+
+
+def convert_data_files(syn, folder_id):
+    """Convert `File` entities into `DatasetItem` entities.
+
+    Assumptions:
+        Immediate children of given Folder ID are File entities.
+
+    Returns:
+        list of `DatasetItem`s
+    """
+    files = syn.getChildren(folder_id)
+    return [
+        {'entityId': f.get('id'), 'versionNumber': f.get('versionLabel')}
+        for f in files
+    ]
+
+
+def convert_folder_to_dataset(syn, dataset_name, schema, dataset_items):
+    """Convert `Folder` entity into `Dataset` entity.
+
+    TODO:
+        Replace REST call with Dataset service function once available.
+    """
+    req_body = {
+        'name': dataset_name,
+        'parentId': PARENT_ID,
+        'concreteType': "org.sagebionetworks.repo.model.table.Dataset",
+        'columnIds': schema,
+        'items': dataset_items
+    }
+    syn.restPOST("/entity", json.dumps(req_body))
+
+
+def main():
+    """Main function."""
+    syn = login()
+
+    # Keep count of conversions done for summary report.
+    folder_count = 0
+    file_count = 0
+    needs_review = []
+
+    # Convert "datasets" in portal DB project.
+    col_ids = create_dataset_schema(syn)
+    for folder in syn.getChildren(FOLDERS_ID):
+        folder_id = folder.get('id')
+        files = convert_data_files(syn, folder_id)
+        try:
+            convert_folder_to_dataset(syn,
+                                      dataset_name=folder.get('name'),
+                                      schema=col_ids,
+                                      dataset_items=files)
+            folder_count += 1
+            file_count += len(files)
+        except synapseclient.core.exceptions.SynapseHTTPError:
+            needs_review.append(folder_id)
+
+    # Print summary report.
+    print(f"      Number of folders converted: {folder_count}")
+    print(f"Number of files added to datasets: {file_count}")
+    with open('needs_review.txt', 'w') as out:
+        for i in needs_review:
+            out.write(i + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/convert_to_dataset.py
+++ b/python/convert_to_dataset.py
@@ -25,10 +25,7 @@ def login():
         syn: Synapse object
     """
     try:
-        syn = synapseclient.login(
-            os.getenv('SYN_USERNAME'),
-            authToken=os.getenv('SYN_PAT'),
-            silent=True)
+        syn = synapseclient.login(silent=True)
     except synapseclient.core.exceptions.SynapseNoCredentialsError:
         print("Credentials not found; please manually provide your",
               "Synapse username and password.")
@@ -79,10 +76,6 @@ def _get_data_files(syn, folder_id):
 def _create_dataset(syn, dataset_name, schema, dataset_items):
     """Create `Dataset` entity.
 
-    Assumptions:
-        dataset_items contains IDs of File entities only; otherwise,
-        SynapseHTTPError is thrown.
-
     TODO:
         Replace REST call with Dataset service function once available.
     """
@@ -108,7 +101,12 @@ def _reset_datasets(syn):
 
 
 def main():
-    """Main function."""
+    """Main function.
+
+    Assumptions:
+        `files` contains IDs of File entities only; otherwise,
+        SynapseHTTPError is thrown.
+    """
     syn = login()
 
     # Keep count of conversions done for summary report.

--- a/python/convert_to_dataset.py
+++ b/python/convert_to_dataset.py
@@ -59,8 +59,9 @@ def create_dataset_schema(syn):
     return [col.get('id') for col in cols]
 
 
-def convert_data_files(syn, folder_id):
-    """Convert `File` entities into `DatasetItem` entities.
+def _get_data_files(syn, folder_id):
+    """Get `File` entities from given Folder ID and format them as
+    `DatasetItem`s.
 
     Assumptions:
         Immediate children of given Folder ID are File entities.
@@ -75,8 +76,12 @@ def convert_data_files(syn, folder_id):
     ]
 
 
-def convert_folder_to_dataset(syn, dataset_name, schema, dataset_items):
-    """Convert `Folder` entity into `Dataset` entity.
+def _create_dataset(syn, dataset_name, schema, dataset_items):
+    """Create `Dataset` entity.
+
+    Assumptions:
+        dataset_items contains IDs of File entities only; otherwise,
+        SynapseHTTPError is thrown.
 
     TODO:
         Replace REST call with Dataset service function once available.
@@ -104,12 +109,12 @@ def main():
     col_ids = create_dataset_schema(syn)
     for folder in syn.getChildren(FOLDERS_ID):
         folder_id = folder.get('id')
-        files = convert_data_files(syn, folder_id)
+        files = _get_data_files(syn, folder_id)
         try:
-            convert_folder_to_dataset(syn,
-                                      dataset_name=folder.get('name'),
-                                      schema=col_ids,
-                                      dataset_items=files)
+            _create_dataset(syn,
+                            dataset_name=folder.get('name'),
+                            schema=col_ids,
+                            dataset_items=files)
             folder_count += 1
             file_count += len(files)
         except synapseclient.core.exceptions.SynapseHTTPError:


### PR DESCRIPTION
Adding script for converting current CSBC/PS-ON "datasets" (Synapse Folders) into the Dataset entity type.

Similar steps from the script can be implemented into the curation workflow once CCKP is configured to support Datasets.  For now, the curation workflow will continue to upload the dataset manifests as Synapse Folders.
